### PR TITLE
Test/movie cards on load

### DIFF
--- a/cypress/e2e/onLoad.cy.js
+++ b/cypress/e2e/onLoad.cy.js
@@ -17,8 +17,13 @@ describe('main page/all movies view', () => {
     cy.get('img.logo').should('be.visible');
   });
   
-
   // test that i see the movie collection
+
+  it('displays the movie collection', () => {
+    console.log(moviesData.length)
+    cy.get('.movie-card').should('have.length', moviesData.movies.length);
+  });
+  
 
   // test that the movieCards contain the right information
 });

--- a/cypress/e2e/onLoad.cy.js
+++ b/cypress/e2e/onLoad.cy.js
@@ -1,7 +1,19 @@
-describe('template spec', () => {
-  it('passes', () => {
-    cy.visit('https://example.cypress.io')
-  })
+import moviesData from "../fixtures/moviesData";
 
-  
-})
+describe('main page/all movies view', () => {
+  beforeEach(() => {
+    cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
+      statusCode: 200,
+      fixture: moviesData
+    });
+    cy.visit('/');
+  });
+
+  // test that the logo is shown on page load
+
+  // test that i see the movie collection
+
+  // test that the movieCards contain the right information
+});
+
+

--- a/cypress/e2e/onLoad.cy.js
+++ b/cypress/e2e/onLoad.cy.js
@@ -36,7 +36,7 @@ describe('main page/all movies view', () => {
 
 describe('main page/all movies view', () => {
 
-    // test that when a server-side (5XX) error is thrown, the user is shown a server-side error message & nothing else
+  // test that when a server-side (5XX) error is thrown, the user is shown a server-side error message & nothing else
 
   it('displays a server-side error message', () => {
     cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
@@ -48,14 +48,32 @@ describe('main page/all movies view', () => {
     cy.wait('@getMovies').then((interception) => {
       expect(interception.response.statusCode).to.equal(500);
     });
-  
+
     cy.contains('.error-message', 'Oops, the server is temporarily down. Please try again later.')
       .should('be.visible');
-  
+
     cy.get('.movie-card').should('not.exist');
   });
 
-    // test that when there is a client-side error (4XX), the user is shown a different message
+  // test that when there is a client-side error (4XX), the user is shown a different message
 
+  it('displays a client-side error message', () => {
+    cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
+      statusCode: 404,
+      body: 'Not Found'
+    }).as('getMovies');
+
+    cy.visit('http://localhost:3000/');
+
+    cy.wait('@getMovies').then((interception) => {
+      expect(interception.response.statusCode).to.equal(404);
+    });
+
+    cy.contains('.error-message', 'Oops! Something went wrong on your end. Please check your network connection and try again.')
+      .should('be.visible');
+
+    cy.get('.movie-card').should('not.exist');
+  });
+  
 });
 

--- a/cypress/e2e/onLoad.cy.js
+++ b/cypress/e2e/onLoad.cy.js
@@ -1,12 +1,14 @@
 import moviesData from "../fixtures/moviesData";
 
+// HAPPY PATH //
+
 describe('main page/all movies view', () => {
   beforeEach(() => {
     cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
       statusCode: 200,
-      fixture: moviesData
+      body: moviesData
     });
-    cy.visit('/');
+    cy.visit('http://localhost:3000/');
   });
 
   // test that the logo is shown on page load

--- a/cypress/e2e/onLoad.cy.js
+++ b/cypress/e2e/onLoad.cy.js
@@ -49,8 +49,12 @@ describe('main page/all movies view', () => {
       expect(interception.response.statusCode).to.equal(500);
     });
 
+    // verify the correct error message is displayed
+
     cy.contains('.error-message', 'Oops, the server is temporarily down. Please try again later.')
       .should('be.visible');
+
+      // verify that the movie-cards are no longer showing
 
     cy.get('.movie-card').should('not.exist');
   });
@@ -69,11 +73,15 @@ describe('main page/all movies view', () => {
       expect(interception.response.statusCode).to.equal(404);
     });
 
+    // verify the correct error message is displayed
+    
     cy.contains('.error-message', 'Oops! Something went wrong on your end. Please check your network connection and try again.')
       .should('be.visible');
 
+      // verify that the movie-cards are no longer showing
+
     cy.get('.movie-card').should('not.exist');
   });
-  
+
 });
 

--- a/cypress/e2e/onLoad.cy.js
+++ b/cypress/e2e/onLoad.cy.js
@@ -20,12 +20,12 @@ describe('main page/all movies view', () => {
   // test that i see the movie collection
 
   it('displays the movie collection', () => {
-    console.log(moviesData.length)
     cy.get('.movie-card').should('have.length', moviesData.movies.length);
   });
-  
 
   // test that the movieCards contain the right information
+
+
 });
 
 

--- a/cypress/e2e/onLoad.cy.js
+++ b/cypress/e2e/onLoad.cy.js
@@ -44,11 +44,18 @@ describe('main page/all movies view', () => {
       body: 'Internal Server Error'
     }).as('getMovies');
     cy.visit('http://localhost:3000/');
+
+    cy.wait('@getMovies').then((interception) => {
+      expect(interception.response.statusCode).to.equal(500);
+    });
+  
+    cy.contains('.error-message', 'Oops, the server is temporarily down. Please try again later.')
+      .should('be.visible');
+  
+    cy.get('.movie-card').should('not.exist');
   });
 
-
-
-
-  // test that when there is a client-side error (4XX), the user is shown a different message
+    // test that when there is a client-side error (4XX), the user is shown a different message
 
 });
+

--- a/cypress/e2e/onLoad.cy.js
+++ b/cypress/e2e/onLoad.cy.js
@@ -1,0 +1,7 @@
+describe('template spec', () => {
+  it('passes', () => {
+    cy.visit('https://example.cypress.io')
+  })
+
+  
+})

--- a/cypress/e2e/onLoad.cy.js
+++ b/cypress/e2e/onLoad.cy.js
@@ -25,6 +25,15 @@ describe('main page/all movies view', () => {
 
   // test that the movieCards contain the right information
 
+it('displays the correct information in movie cards', () => {
+  cy.get('.movie-card').each(($card, index) => {
+    const movie = moviesData.movies[index];
+    cy.assertMovieCard($card, movie);
+  });
+});
+  
+  
+
 
 });
 

--- a/cypress/e2e/onLoad.cy.js
+++ b/cypress/e2e/onLoad.cy.js
@@ -13,6 +13,11 @@ describe('main page/all movies view', () => {
 
   // test that the logo is shown on page load
 
+  it('displays the app logo on page load', () => {
+    cy.get('img.logo').should('be.visible');
+  });
+  
+
   // test that i see the movie collection
 
   // test that the movieCards contain the right information

--- a/cypress/e2e/onLoad.cy.js
+++ b/cypress/e2e/onLoad.cy.js
@@ -16,25 +16,39 @@ describe('main page/all movies view', () => {
   it('displays the app logo on page load', () => {
     cy.get('img.logo').should('be.visible');
   });
-  
+
   // test that i see the movie collection
 
   it('displays the movie collection', () => {
     cy.get('.movie-card').should('have.length', moviesData.movies.length);
   });
 
-  // test that the movieCards contain the right information
+  // test that the movieCards contain the right information -- using custom command (support file)
 
-it('displays the correct information in movie cards', () => {
-  cy.get('.movie-card').each(($card, index) => {
-    const movie = moviesData.movies[index];
-    cy.assertMovieCard($card, movie);
+  it('displays the correct information in movie cards', () => {
+    cy.get('.movie-card').each(($card, index) => {
+      const movie = moviesData.movies[index];
+      cy.assertMovieCard($card, movie);
+    });
+  })
+});
+
+
+describe('main page/all movies view', () => {
+
+    // test that when a server-side (5XX) error is thrown, the user is shown a server-side error message & nothing else
+
+  it('displays a server-side error message', () => {
+    cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
+      statusCode: 500,
+      body: 'Internal Server Error'
+    }).as('getMovies');
+    cy.visit('http://localhost:3000/');
   });
+
+
+
+
+  // test that when there is a client-side error (4XX), the user is shown a different message
+
 });
-  
-  
-
-
-});
-
-

--- a/cypress/fixtures/moviesData.js
+++ b/cypress/fixtures/moviesData.js
@@ -1,0 +1,28 @@
+{
+  movies: [
+      {
+          "id": 436270,
+          "poster_path": "https://image.tmdb.org/t/p/original//pFlaoHTZeyNkG83vxsAJiGzfSsa.jpg",
+          "backdrop_path": "https://image.tmdb.org/t/p/original//bQXAqRx2Fgc46uCVWgoPz5L5Dtr.jpg",
+          "title": "Black Adam",
+          "average_rating": 4,
+          "release_date": "2022-10-19"
+      },
+      {
+          "id": 724495,
+          "poster_path": "https://image.tmdb.org/t/p/original//438QXt1E3WJWb3PqNniK0tAE5c1.jpg",
+          "backdrop_path": "https://image.tmdb.org/t/p/original//7zQJYV02yehWrQN6NjKsBorqUUS.jpg",
+          "title": "The Woman King",
+          "average_rating": 4,
+          "release_date": "2022-09-15"
+      },
+      {
+          "id": 1013860,
+          "poster_path": "https://image.tmdb.org/t/p/original//g4yJTzMtOBUTAR2Qnmj8TYIcFVq.jpg",
+          "backdrop_path": "https://image.tmdb.org/t/p/original//kmzppWh7ljL6K9fXW72bPN3gKwu.jpg",
+          "title": "R.I.P.D. 2: Rise of the Damned",
+          "average_rating": 7,
+          "release_date": "2022-11-15"
+      }
+    ]
+  }

--- a/cypress/fixtures/moviesData.js
+++ b/cypress/fixtures/moviesData.js
@@ -1,5 +1,5 @@
-{
-  movies: [
+const moviesData = {
+  "movies": [
       {
           "id": 436270,
           "poster_path": "https://image.tmdb.org/t/p/original//pFlaoHTZeyNkG83vxsAJiGzfSsa.jpg",
@@ -26,3 +26,5 @@
       }
     ]
   }
+
+  export default moviesData;

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,16 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+
+Cypress.Commands.add('assertMovieCard', ($card, movie) => {
+  const { title, poster_path, release_date, average_rating } = movie;
+  const roundedRating = Math.round(average_rating * 10) / 10;
+
+  cy.wrap($card).within(() => {
+    cy.get('h2').should('have.text', title);
+    cy.get('.movie-poster').should('have.attr', 'src', poster_path).and('have.attr', 'alt', title);
+    cy.get('p').eq(0).should('have.text', release_date.split('-')[0]);
+    cy.get('p').eq(1).should('have.text', `Rating: ${roundedRating}/10`);
+  });
+});
+

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,15 +24,16 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
+
 Cypress.Commands.add('assertMovieCard', ($card, movie) => {
-  const { title, poster_path, release_date, average_rating } = movie;
-  const roundedRating = Math.round(average_rating * 10) / 10;
+  const roundedRating = Math.round(movie.average_rating * 10) / 10;
 
   cy.wrap($card).within(() => {
-    cy.get('h2').should('have.text', title);
-    cy.get('.movie-poster').should('have.attr', 'src', poster_path).and('have.attr', 'alt', title);
-    cy.get('p').eq(0).should('have.text', release_date.split('-')[0]);
+    cy.get('h2').should('have.text', movie.title);
+    cy.get('.movie-poster').should('have.attr', 'src', movie.poster_path).and('have.attr', 'alt', movie.title);
+    cy.get('p').eq(0).should('have.text', movie.release_date.split('-')[0]);
     cy.get('p').eq(1).should('have.text', `Rating: ${roundedRating}/10`);
   });
 });
+
 


### PR DESCRIPTION
## Description of Changes Made

Tests created to determine the successful loading of the application: 
-- Verified the main page loads without errors
-- Verified that the app's logo is displayed on load
-- Checked if the movie cards are displayed properly
-- Verified that each card is displaying the correct information using a custom command

Sad Path created to handle both client & server side errors
--  tested that when a server-side (5XX) error is thrown, the user is shown a server-side error message & no movie cards
-- tested that when a client-side (4XX) error is thrown, the user is shown a server-side error message & no movie cards
--  verify the correct error message is displayed for each error

## Issue ticket number and link

closes #7 
closes #8
closes #42
closes #43

## What's next?

Testing the navigation functionality of the home button

## Did this break anything?
- [X] No
- [ ] Yes

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Testing - Cypress
- [ ] Refactor(DRY-ing up/ reorganizing code, etc.)
- [X] Super small fix (Corrected a typo, removed a comment, etc.)
- [ ] Skip all the other stuff and briefly explain the fix.

## Checklist before requesting a review
- [X] If this code needs to be tested, all tests are passing
- [X] The code runs locally
- [X] There are comments where clarification/ organization is needed
- [X] The code is DRY. If it's not, I tried my best
- [X] I reviewed my code before pushing
